### PR TITLE
bugfix: shift AABB coordinates for boxes

### DIFF
--- a/crash.js
+++ b/crash.js
@@ -305,11 +305,12 @@
     Crash.updateAABBBox = Crash.prototype.updateAABBBox = function(collider) {
         var points = collider.sat.calcPoints;
         var aabb = collider.aabb;
-        
-        aabb.x1 = points[0].x;
-        aabb.y1 = points[0].y;
-        aabb.x2 = points[2].x;
-        aabb.y2 = points[2].y;
+        var pos = collider.sat.pos;
+
+        aabb.x1 = pos.x + points[0].x;
+        aabb.y1 = pos.y + points[0].y;
+        aabb.x2 = pos.x + points[2].x;
+        aabb.y2 = pos.y + points[2].y;
     }
     
     


### PR DESCRIPTION
Hello,

I noticed that the AABB coordinates of boxes do not seem to take the position of the box into account.

Here is an example that shows the bug:
```
const Crash = require('crash-colliders');
let crash = new Crash();
let listener = (a, b, res, cancel) => {
    console.log("CRASH");
};
crash.onCollision(listener);
let box = new crash.Box(new crash.Vector(100, -30), 200, 200);
let circle = new crash.Circle(new crash.Vector(100, -30), 28);
crash.insert(box);
crash.insert(circle);
crash.moved(box);
crash.moved(circle);
console.log(crash.search(circle));
for (let id in crash.rbush.toJSON().children) {
    console.log(crash.rbush.toJSON().children[id].aabb);
}
crash.check();
```
They should crash, but the output is:
```
[]
{ x1: 0, y1: 0, x2: 200, y2: 200 }
{ x1: 72, y1: -58, x2: 128, y2: -2 }
```
As you can see, the AABB coordinates are wrong.

I suspected that this could also be due to a version mismatch of SAT, but it seems to be correct (it is 0.5.0). 

